### PR TITLE
Fix typo in hw 8

### DIFF
--- a/unit08_svm/lab_emnist_partial.ipynb
+++ b/unit08_svm/lab_emnist_partial.ipynb
@@ -191,7 +191,7 @@
    },
    "outputs": [],
    "source": [
-    "# TODO 2:  Load the digit data from emnist-letters.mat\n",
+    "# TODO 2:  Load the letter data from emnist-letters.mat\n",
     "# Xtr_let, Xts_let, ytr_let, yts_let = ..."
    ]
   },


### PR DESCRIPTION
TODO 2 should be load letter data, the typo is a bit confusing